### PR TITLE
Feature/samesite cookie

### DIFF
--- a/06-security.md
+++ b/06-security.md
@@ -106,13 +106,29 @@ Session Cookies must have the flags `http-only` and `secure` set. Http-only mean
 ### Protect the Session against Cross Site Request Forgery (XSRF)
 
 A malicious browser tab may send requests to the API while the user is logged in. These requests will be sent with the correct session id by the browser. 
-To prevent abuse an additional token must be sent with each write operation, the `XSRF-TOKEN`. The token name used in this convention is the default for AngularJS.  
+
+#### Tokens
+
+To prevent abuse an additional token must be sent with each write operation, the `XSRF-TOKEN`. The token name used in this convention is the default for AngularJS.
 
 Typically the token is sent to the browser in the form of a cookie by the first GET request to the API, read by the JavaScript on the page and added as a request header (`X-XSRF-TOKEN`) to subsequent PUT, POST or DELETE request.  The API checks the presence of the correct header on the request. If not correct, the request fails.
  
 The malicious tab cannot read the contents of the `XSRF-TOKEN` cookie as it is on a different domain. 
     
 An XSRF token is assigned to the browser on the first GET request. XSRF cookies MUST have the flag `secure` set. The API must check PUT, POST, PATCH and DELETE requests for the presence of the correct XSRF token.
+
+#### SameSite Cookie Flag
+
+The `SameSite` cookie flag is an alternative for sending XSRF-TOKENs. 
+When the flag is set on a cookie the browser will only send the cookie to hosts that match the origin of the page.
+The cookie has two possible values: 
+- `strict` which disallows any cross site usage.
+- `lax` which allows some cross site usage, like in links, and Forms that use GET request.
+
+Browser support however, [is limited](http://caniuse.com/#search=SameSite). So far only Chrome and Opera support the cookie. 
+Backend support is also limited; Currently Tomcat nor the Servlet API support it, however it is possible to add the flag manually using a request filter.
+
+Because of the current limited support the `SameSite` cookie cannot not be relied upon. You can use it but only when also using Tokens.
 
 ### Authentication
 

--- a/06-security.md
+++ b/06-security.md
@@ -123,14 +123,14 @@ The `SameSite` [cookie flag](https://tools.ietf.org/html/draft-ietf-httpbis-cook
 When the flag is set on a cookie the browser will only send the cookie to hosts that match the origin of the page.
 The cookie has two possible values: 
 - `strict` which disallows any cross site usage.
-- `lax` which allows some cross site usage, like in links, and Forms that use GET request.
+- `lax` which allows some cross site usage, like in links and Forms that use GET request.
 
-Browser support however, [is limited](http://caniuse.com/#search=SameSite). So far only Chrome and Opera support the cookie. 
+Browser support however [is limited](http://caniuse.com/#search=SameSite). So far only Chrome and Opera support the cookie. 
 Backend support is also limited; Currently Tomcat nor the Servlet API support it, however it is possible to add the flag manually using a request filter.
 
 Because of the current limited support the `SameSite` cookie _cannot_ not be relied upon. You can use it but only when also using Tokens.
 
-For a more thorough explanation read [this blog-post](https://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/).
+For a more thorough explanation read [this blog post](https://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/).
 
 ### Authentication
 

--- a/06-security.md
+++ b/06-security.md
@@ -119,7 +119,7 @@ An XSRF token is assigned to the browser on the first GET request. XSRF cookies 
 
 #### SameSite Cookie Flag
 
-The `SameSite` cookie flag is an alternative for sending XSRF-TOKENs. 
+The `SameSite` [cookie flag](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00) is an alternative for sending XSRF-TOKENs. 
 When the flag is set on a cookie the browser will only send the cookie to hosts that match the origin of the page.
 The cookie has two possible values: 
 - `strict` which disallows any cross site usage.
@@ -128,7 +128,9 @@ The cookie has two possible values:
 Browser support however, [is limited](http://caniuse.com/#search=SameSite). So far only Chrome and Opera support the cookie. 
 Backend support is also limited; Currently Tomcat nor the Servlet API support it, however it is possible to add the flag manually using a request filter.
 
-Because of the current limited support the `SameSite` cookie cannot not be relied upon. You can use it but only when also using Tokens.
+Because of the current limited support the `SameSite` cookie _cannot_ not be relied upon. You can use it but only when also using Tokens.
+
+For a more thorough explanation read [this blog-post](https://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/).
 
 ### Authentication
 


### PR DESCRIPTION
I've added a section on the use of the SameSite cookie flag (which prevents cross site request forgery).

Although current (browser/backend) support is limited it is a really good solution and much more convenient that the token based approach. When support becomes mainstream we should migrate to this method. For now, tokens remain mandatory.